### PR TITLE
Bump pyOpenSSL

### DIFF
--- a/requirements-kdabci.txt
+++ b/requirements-kdabci.txt
@@ -15,7 +15,7 @@ click==7.1.2
 click-default-group==1.2.2
 constantly==15.1.0
 croniter==1.4.1
-cryptography==3.4.6
+cryptography==41.0.7
 cssselect2==0.4.1
 decorator==4.4.2
 defusedxml==0.6.0
@@ -65,7 +65,7 @@ Pygments==2.8.0
 PyHamcrest==2.0.2
 PyJWT==2.0.1
 pylint==3.0.4
-pyOpenSSL==20.0.1
+pyOpenSSL==23.2.0
 pyparsing==2.4.7
 pypugjs==5.9.9
 python-dateutil==2.8.1


### PR DESCRIPTION
Otherwise getting an error from twisted startup:

AttributeError: module 'lib' has no attribute
'X509_V_FLAG_NOTIFY_POLICY'. Did you mean:
'X509_V_FLAG_EXPLICIT_POLICY'?


